### PR TITLE
build: support ES6 tree-shaking

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -23,7 +24,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-bibjson/package.json
+++ b/packages/plugin-bibjson/package.json
@@ -9,6 +9,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -22,7 +23,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-bibtex/package.json
+++ b/packages/plugin-bibtex/package.json
@@ -11,6 +11,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -24,7 +25,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-csl/package.json
+++ b/packages/plugin-csl/package.json
@@ -10,6 +10,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -23,7 +24,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-doi/package.json
+++ b/packages/plugin-doi/package.json
@@ -11,7 +11,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "src/index.js"
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/plugin-doi/package.json
+++ b/packages/plugin-doi/package.json
@@ -11,6 +11,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js"
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -24,7 +25,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-ris/package.json
+++ b/packages/plugin-ris/package.json
@@ -9,6 +9,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -22,7 +23,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"

--- a/packages/plugin-wikidata/package.json
+++ b/packages/plugin-wikidata/package.json
@@ -10,6 +10,7 @@
   "author": "Lars Willighagen <lars.willighagen@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "directories": {
     "lib": "src",
     "test": "__tests__"
@@ -23,7 +24,8 @@
     "node": ">=6.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "test": "mocha -c -R dot test/*.spec.js"


### PR DESCRIPTION
Tools like Webpack and Rollup support tree-shaking with ES6 modules. Adding the "module" field and "src" to the "files" field in package.json should be all that is needed.