### PR TITLE
docs: fix broken tutorial links

### DIFF
--- a/packages/core/docs/cite.md
+++ b/packages/core/docs/cite.md
@@ -4,7 +4,7 @@ Central to Citation.js is the `Cite` constructor. This document explains how to 
 const example = new Cite(data, options)
 ```
 
-`data` can be any of the input types listed in {@tutorial input_types}. Some of the main ones:
+`data` can be any of the input types listed in {@tutorial input_formats}. Some of the main ones:
 
   * DOIs, lists of DOIs, a file with DOIs, or a `doi.org` URL
   * Wikidata IDs, lists of IDs, a file with IDs, a Wikidata API URL, Wikidata JSON response

--- a/packages/core/docs/cite_constructor.md
+++ b/packages/core/docs/cite_constructor.md
@@ -4,7 +4,7 @@ Create a new instance of `Cite`:
 new Cite(data[, options])
 ```
 
-* `data` can be any of the input types listed in {@tutorial input_types}
+* `data` can be any of the input types listed in {@tutorial input_formats}
 * `options` is an optional object with the input options listed in {@tutorial input_options}
 
 ## Example

--- a/packages/core/docs/input_options.md
+++ b/packages/core/docs/input_options.md
@@ -5,4 +5,4 @@ Input options are the ones below.
 | `output`         | {}            | Default {@tutorial output_options}, used when calling `Cite#get()`     |
 | `maxChainLength` | 10            | Max number of parsing iterations used when parsing                     |
 | `generateGraph`  | true          | Generate a parsing chain graph. Holds info on how an entry was parsed. |
-| `forceType`      | undefined     | Force parsing as a certain {@tutorial input_types}, if the type checking methods fail (or are slow, and you already know what the input type is, etc.) |
+| `forceType`      | undefined     | Force parsing as a certain {@tutorial input_formats}, if the type checking methods fail (or are slow, and you already know what the input type is, etc.) |

--- a/packages/core/docs/input_plugins.md
+++ b/packages/core/docs/input_plugins.md
@@ -44,7 +44,7 @@ _*: optional_
 
 ### `type`
 
-The `type` is the name of the {@tutorial input_types}, and are recommended to be in the syntax shown below. Alternative syntaxes include `@scope` and `@scope/format`. Examples:
+The `type` is the name of the {@tutorial input_formats}, and are recommended to be in the syntax shown below. Alternative syntaxes include `@scope` and `@scope/format`. Examples:
 
   * `@bibtex/text` for a series of BibTeX entries
   * `@wikidata/list+string` for a list of Wikidata IDs separated by spaces/newlines/commas

--- a/packages/core/src/Cite/index.js
+++ b/packages/core/src/Cite/index.js
@@ -6,10 +6,10 @@ import * as get from './get'
 import * as staticMethods from './static'
 
 /**
- * Citation.js input data, see {@tutorial input_types}
+ * Citation.js input data, see {@tutorial input_formats}
  *
  * @typedef InputData
- * @tutorial input_types
+ * @tutorial input_formats
  */
 
 /**


### PR DESCRIPTION
There are some references to a tutorial input_types, which should be input_formats.