### PR TITLE
Ignore braces used for grouping commands

### DIFF
--- a/packages/plugin-bibtex/src/input/text.js
+++ b/packages/plugin-bibtex/src/input/text.js
@@ -225,6 +225,27 @@ export const bibtexGrammar = new util.Grammar({
     return output
   },
 
+  BracketText () {
+    let output = ''
+    this.consumeToken('lbrace')
+
+    // Ignore braces as long as they are used for grouping commands
+    while (this.matchToken('command')) {
+      output += this.consumeRule('Command')
+    }
+
+    // If a non-command is encountered before closing, add braces to output
+    if (!this.matchToken('rbrace')) {
+      do {
+        output += this.consumeRule('Text')
+      } while (!this.matchToken('rbrace'))
+      output = `{${output}}`
+    }
+
+    this.consumeToken('rbrace')
+    return output
+  },
+
   MathString () {
     let output = ''
     this.consumeToken('mathShift')
@@ -243,7 +264,7 @@ export const bibtexGrammar = new util.Grammar({
 
   Text () {
     if (this.matchToken('lbrace')) {
-      return `{${this.consumeRule('BracketString')}}`
+      return this.consumeRule('BracketText')
     } else if (this.matchToken('mathShift')) {
       return this.consumeRule('MathString')
     } else if (this.matchToken('whitespace')) {

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -94,6 +94,22 @@
         }
       }]
     ],
+    "with authors with non-ASCII characters": [
+      "@article{myarticle, author={von Helmholtz, Hermann and von Helmhöltz, Hermänn and von Helmh\\\"oltz, Herm\\\"ann and von Helmh{\\\"o}ltz, Herm{\\\"a}nn}}",
+      [
+        {
+          "citation-label": "myarticle",
+          "id": "myarticle",
+          "type": "article-journal",
+          "author": [
+            {"family": "Helmholtz", "given": "Hermann", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"}
+          ]
+        }
+      ]
+    ],
     "with year and month without date": [
       "@a{b,year=2017,month=8}",
       [{


### PR DESCRIPTION
Springer (and others) [surround TeX commands for diacritics with braces within BibTeX fields](https://citation-needed.springer.com/v2/references/10.1007/978-3-642-13486-9_1?format=bibtex&flavour=citation).

This currently forces names such as `Hyv{\"o}nen, Eero` to be interpreted as `literal`:

```json
{ "literal": "Hyvönen, Eero" }
```

whereas the equivalent without braces would be parsed properly:

```json
{ "given": "Eero", "family": "Hyvönen" }
```

This PR ignores braces when they are only used to group commands.