### PR TITLE
Normalize DOIs

### DIFF
--- a/packages/plugin-ris/src/converters.js
+++ b/packages/plugin-ris/src/converters.js
@@ -2,6 +2,7 @@ import { parse as parseDate } from '@citation-js/date'
 import TYPES from './spec/types'
 
 const ISSN_REGEX = /^\d{4}-\d{4}$/
+const DOI_REGEX = /10(?:\.[0-9]{4,})?\/[^\s]*[^\s\.,]/
 const CONVERTERS = {
   ANY: {
     toTarget (...values) { return values.find(Boolean) },
@@ -66,6 +67,11 @@ const CONVERTERS = {
   TYPE: {
     toTarget (type) { return TYPES.RIS[type] },
     toSource (type) { return TYPES.CSL[type] }
+  },
+
+  DOI: {
+    toTarget (doi) { return doi.match(DOI_REGEX) },
+    toSource (doi) { return doi.match(DOI_REGEX) }
   }
 }
 

--- a/packages/plugin-ris/src/converters.js
+++ b/packages/plugin-ris/src/converters.js
@@ -70,8 +70,8 @@ const CONVERTERS = {
   },
 
   DOI: {
-    toTarget (doi) { return doi.match(DOI_REGEX) },
-    toSource (doi) { return doi.match(DOI_REGEX) }
+    toTarget (doi) { return doi.match(DOI_REGEX)[0] },
+    toSource (doi) { return doi.match(DOI_REGEX)[0] }
   }
 }
 

--- a/packages/plugin-ris/src/dataTypes.json
+++ b/packages/plugin-ris/src/dataTypes.json
@@ -24,5 +24,6 @@
   "ISSN,ISBN": "ISBN",
   "keyword": "KEYWORD",
   "page": "PAGE",
-  "type": "TYPE"
+  "type": "TYPE",
+  "DOI": "DOI"
 }

--- a/packages/plugin-ris/test/input.js
+++ b/packages/plugin-ris/test/input.js
@@ -45,6 +45,52 @@ module.exports = {
           id: 'Trentini2019'
         }
       ]
+    ],
+    'BMC 002': [
+      {
+        TY: 'JOUR',
+        AU:
+         [ 'Trentini, Filippo',
+           'Poletti, Piero',
+           'Melegaro, Alessia',
+           'Merler, Stefano' ],
+        PY: '2019',
+        DA: '2019/05/17',
+        TI:
+         'The introduction of ‘No jab, No school’ policy and the refinement of measles immunisation strategies in high-income countries',
+        JO: 'BMC Medicine',
+        SP: '86',
+        VL: '17',
+        IS: '1',
+        AB:
+         'In recent years, we witnessed a resurgence of measles even in countries where, according to WHO guidelines, elimination should have already been achieved. In high-income countries, the raise of anti-vaccination movements and parental vaccine hesitancy are posing major challenges for the achievement and maintenance of high coverage during routine programmes. Italy and France approved new regulations, respectively in 2017 and 2018, aimed at raising immunisation rates among children by introducing mandatory vaccination at school entry.',
+        SN: '1741-7015',
+        UR: 'https://doi.org/10.1186/s12916-019-1318-5',
+        DO: 'doi: 10.1186/s12916-019-1318-5',
+        ID: 'Trentini2019'
+      },
+      [
+        {
+          type: 'article-journal',
+          author: [
+            { family: 'Trentini', given: 'Filippo' },
+            { family: 'Poletti', given: 'Piero' },
+            { family: 'Melegaro', given: 'Alessia' },
+            { family: 'Merler', given: 'Stefano' }
+          ],
+          issued: { 'date-parts': [[2019, 5, 17]] },
+          title: 'The introduction of ‘No jab, No school’ policy and the refinement of measles immunisation strategies in high-income countries',
+          'container-title': 'BMC Medicine',
+          page: '86',
+          volume: '17',
+          issue: '1',
+          abstract: 'In recent years, we witnessed a resurgence of measles even in countries where, according to WHO guidelines, elimination should have already been achieved. In high-income countries, the raise of anti-vaccination movements and parental vaccine hesitancy are posing major challenges for the achievement and maintenance of high coverage during routine programmes. Italy and France approved new regulations, respectively in 2017 and 2018, aimed at raising immunisation rates among children by introducing mandatory vaccination at school entry.',
+          ISSN: '1741-7015',
+          URL: 'https://doi.org/10.1186/s12916-019-1318-5',
+          DOI: '10.1186/s12916-019-1318-5',
+          id: 'Trentini2019'
+        }
+      ]
     ]
   }
 }


### PR DESCRIPTION
Accomodates both DOI (`10.1234/abcd.1234`) and shortDOI (`10/abc1231`) formats

Closes https://github.com/citation-js/citation-js/issues/63