### PR TITLE
Support all 10 escaped characters

### DIFF
--- a/packages/plugin-bibtex/src/input/constants.js
+++ b/packages/plugin-bibtex/src/input/constants.js
@@ -60,6 +60,9 @@ export const diacritics = {
 export const commands = {
   // other
   '~': '\u223C',
+  '_': '\u005f',
+  '{': '\u007B',
+  '}': '\u007D',
   'c\\ ': '\u00B8', // TODO
   href: '',
   url: '',
@@ -94,6 +97,8 @@ export const commands = {
   textasciicircum: '\u02C6',
   textasciidieresis: '\u00A8',
   textasciimacron: '\u00AF',
+  textasciitilde: '\u223C',
+  textbackslash: '\u005C',
   textbardbl: '\u2016',
   textbrokenbar: '\u00A6',
   textbullet: '\u2022',

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -70,6 +70,12 @@
         "citation-label": "Fau86"
       }]
     ],
+    "with escaped characters": [
+      "@article{escape, title={a\\&b\\%c\\$d\\#e\\_f\\textasciitilde{}\\textasciicircum{}\\textbackslash{}}}",
+      [
+        {"type": "article-journal", "id": "escape", "citation-label": "escape", "title": "a&b%c$d#e_f∼ˆ\\"}
+      ]
+    ],
     "with rich text": [
       "@misc{ibscsupsub, title={{\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}}, } @misc{sc, title={{\\textsc{sc}}}, } @misc{sc, title={{{sc}}}, }",
       [


### PR DESCRIPTION
https://tex.stackexchange.com/a/34586/16069 lists all 10 escaped characters; this PR adds support for the remaining ones.

Warning: you will notice that `{` and `}` are not tested; this is because downstream, they will be considered as grouping braces rather than literal braces. In other words, `parseBibTeXProp` actually comes "too late" in the process, when the difference between grouping braces and literal braces has been decoded away.