### PR TITLE
Normalize BibTeX strings

### DIFF
--- a/packages/plugin-bibtex/src/input/constants.js
+++ b/packages/plugin-bibtex/src/input/constants.js
@@ -59,7 +59,6 @@ export const diacritics = {
 // https://github.com/zotero/translators/blob/da31de8/BibTeX.js#L2352-L2875
 export const commands = {
   // other
-  '~': '\u223C',
   '_': '\u005f',
   '{': '\u007B',
   '}': '\u007D',

--- a/packages/plugin-bibtex/src/input/text.js
+++ b/packages/plugin-bibtex/src/input/text.js
@@ -263,21 +263,23 @@ export const bibtexGrammar = new util.Grammar({
   },
 
   Text () {
+    let raw;
     if (this.matchToken('lbrace')) {
-      return this.consumeRule('BracketText')
+      raw = this.consumeRule('BracketText')
     } else if (this.matchToken('mathShift')) {
-      return this.consumeRule('MathString')
+      raw = this.consumeRule('MathString')
     } else if (this.matchToken('whitespace')) {
       this.consumeToken('whitespace')
-      return ' '
+      raw = ' '
     } else if (this.matchToken('command')) {
-      return this.consumeRule('Command')
+      raw = this.consumeRule('Command')
     } else {
-      return this.consumeToken('text').value.replace(
+      raw = this.consumeToken('text').value.replace(
         constants.ligaturePattern,
         ligature => constants.ligatures[ligature]
       )
     }
+    return raw.normalize();
   },
 
   Command () {

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -61,7 +61,7 @@
         "author": [
           {"given": "J.W.", "family": "Goethe"}
         ],
-        "title": "Faust. Der Tragödie Erster Teil",
+        "title": "Faust. Der Tragödie Erster Teil",
         "publisher": "Reclam",
         "issued": {"date-parts": [["1986"]]},
         "publisher-place": "Stuttgart",
@@ -110,8 +110,8 @@
           "author": [
             {"family": "Helmholtz", "given": "Hermann", "non-dropping-particle": "von"},
             {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
-            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
-            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"}
+            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"}
           ]
         }
       ]

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -101,7 +101,7 @@
       }]
     ],
     "with authors with non-ASCII characters": [
-      "@article{myarticle, author={von Helmholtz, Hermann and von Helmhöltz, Hermänn and von Helmh\\\"oltz, Herm\\\"ann and von Helmh{\\\"o}ltz, Herm{\\\"a}nn}}",
+      "@article{myarticle, author={von Helmholtz, Hermann and von Helmhöltz, Hermänñ and von Helmh\\\"oltz, Herm\\\"an\\~n and von Helmh{\\\"o}ltz, Herm{\\\"a}n{\\~n}}}",
       [
         {
           "citation-label": "myarticle",
@@ -109,9 +109,9 @@
           "type": "article-journal",
           "author": [
             {"family": "Helmholtz", "given": "Hermann", "non-dropping-particle": "von"},
-            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
-            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"},
-            {"family": "Helmhöltz", "given": "Hermänn", "non-dropping-particle": "von"}
+            {"family": "Helmhöltz", "given": "Hermänñ", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänñ", "non-dropping-particle": "von"},
+            {"family": "Helmhöltz", "given": "Hermänñ", "non-dropping-particle": "von"}
           ]
         }
       ]

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -76,6 +76,12 @@
         {"type": "article-journal", "id": "escape", "citation-label": "escape", "title": "a&b%c$d#e_f∼ˆ\\"}
       ]
     ],
+    "with math": [
+      "@article{math, title={$e=mc^2$}}",
+      [
+        {"type": "article-journal", "id": "math", "citation-label": "math", "title": "e=mc²"}
+      ]
+    ],
     "with rich text": [
       "@misc{ibscsupsub, title={{\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}}, } @misc{sc, title={{\\textsc{sc}}}, } @misc{sc, title={{{sc}}}, }",
       [


### PR DESCRIPTION
The current BibTeX parser will return different results when parsing the equivalent strings `cät` and `c\"at`. Moreover, the return value for the latter results in invalid BibTeX (unicode chacters out of range).

This PR normalizes the outputted strings. In addition, it also fixes the specific case of tildes.