### PR TITLE
Recognize braced family name in BibTeX

### DIFF
--- a/packages/plugin-bibtex/src/input/prop.js
+++ b/packages/plugin-bibtex/src/input/prop.js
@@ -62,8 +62,17 @@ const parseBibtexDate = function (value) {
  * @return {Object} CSL name object
  */
 const parseBibtexName = function (name) {
+  // Braces serve as special signals
   if (/{|}/.test(name)) {
-    return { literal: name.replace(/[{}]/g, '') }
+    // Recognize a family name surrounded by braces
+    const match = /^([^{}]+)\s+{([^{}]+)}$/.exec(name);
+    if (match) {
+      return { given: match[1], family: match[2] };
+    // Treat other brace constructions as literal text
+    } else {
+      return { literal: name.replace(/{|}/g, '') }
+    }
+  // No braces, parse regular name
   } else {
     return parseName(name)
   }

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -106,6 +106,32 @@
         }
       }]
     ],
+    "with an author that has a braced family name": [
+      "@article{myarticle, author={Hermann {von Helmholtz}}}",
+      [
+        {
+          "citation-label": "myarticle",
+          "id": "myarticle",
+          "type": "article-journal",
+          "author": [
+            {"family": "von Helmholtz", "given": "Hermann"}
+          ]
+        }
+      ]
+    ],
+    "with an author in braces": [
+      "@article{myarticle, author={{Acme Inc.}}}",
+      [
+        {
+          "citation-label": "myarticle",
+          "id": "myarticle",
+          "type": "article-journal",
+          "author": [
+            {"literal": "Acme Inc."}
+          ]
+        }
+      ]
+    ],
     "with authors with non-ASCII characters": [
       "@article{myarticle, author={von Helmholtz, Hermann and von Helmhöltz, Hermänñ and von Helmh\\\"oltz, Herm\\\"an\\~n and von Helmh{\\\"o}ltz, Herm{\\\"a}n{\\~n}}}",
       [


### PR DESCRIPTION
Some BibTeX sources (like IEEE) surround the family name by braces. This is also described in https://www.tug.org/TUGboat/tb27-2/tb87hufflen.pdf#page=2 (below Remark 1).

This PR adds support for such names.