### PR TITLE
Correctly represent small caps in all parsed BibTeX fields

### DIFF
--- a/packages/plugin-bibtex/src/input/prop.js
+++ b/packages/plugin-bibtex/src/input/prop.js
@@ -97,11 +97,11 @@ const parseBibtexNameList = function (list) {
 }
 
 const richTextMappings = {
-  textit: 'i',
-  textbf: 'b',
-  textsc: 'sc',
-  textsuperscript: 'sup',
-  textsubscript: 'sub'
+  textit: ['i'],
+  textbf: ['b'],
+  textsc: ['span', 'style="font-variant: small-caps;"'],
+  textsuperscript: ['sup'],
+  textsubscript: ['sub']
 }
 
 /**
@@ -126,12 +126,12 @@ const parseBibtexRichText = function (text) {
 
     // handle commands
     } else if (token[0] === '\\') {
-      let tag = richTextMappings[token.slice(1, -1)]
+      let [tag, attributes] = richTextMappings[token.slice(1, -1)]
 
       // handle known style tags
       if (tag) {
         closingTags.push(`</${tag}>`)
-        return `<${tag}>`
+        return !attributes ? `<${tag}>` : `<${tag} ${attributes}>`
 
       // handle other commands
       } else {

--- a/packages/plugin-bibtex/src/input/prop.js
+++ b/packages/plugin-bibtex/src/input/prop.js
@@ -248,16 +248,17 @@ const parseBibTeXProp = function (name, value) {
       case 'issued':
         return parseBibtexDate(value)
 
-      case 'edition':
-        // return parseOrdinal(value)
-        return value
-
       case 'issued:date-parts.0.1':
         return parseFloat(value) ? value : months.findIndex(month => month.test(value)) + 1
 
       case 'page':
         return value.replace(/[—–]/, '-')
 
+      case 'collection-title':
+      case 'container-title':
+      case 'note':
+      case 'publisher':
+      case 'publisher-place':
       case 'title':
         return parseBibtexRichText(value)
 

--- a/packages/plugin-bibtex/src/output/text.js
+++ b/packages/plugin-bibtex/src/output/text.js
@@ -36,10 +36,9 @@ function escapeValue (value) {
 const richTextMappings = {
   'i': '\\textit{',
   'b': '\\textbf{',
-  'sc': '\\textsc{',
   'sup': '\\textsuperscript{',
   'sub': '\\textsubscript{',
-  'span style="font-variant:small-caps;"': '\\textsc{',
+  'span style="font-variant: small-caps;"': '\\textsc{',
   'span class="nocase"': '{'
 }
 

--- a/packages/plugin-bibtex/src/output/text.js
+++ b/packages/plugin-bibtex/src/output/text.js
@@ -59,15 +59,8 @@ function serializeRichTextValue (value) {
   return tokens.join('')
 }
 
-const richTextFields = ['title']
-
 function serializeValue (prop, value, dict) {
-  if (richTextFields.includes(prop)) {
-    value = serializeRichTextValue(value)
-  } else {
-    value = escapeValue(value)
-  }
-
+  value = serializeRichTextValue(value)
   return dict.listItem.join(`${prop} = {${value}},`)
 }
 

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -83,10 +83,10 @@
       ]
     ],
     "with rich text": [
-      "@misc{ibscsupsub, title={\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}, } @misc{sc, title={\\textsc{sc}}, } @misc{sc, title={{{sc}}}, }",
+      "@misc{ibscsupsub, title={\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}, } @misc{sc, booktitle={\\textsc{sc}}, } @misc{sc, title={{{sc}}}, }",
       [
         {"type": "book", "id": "ibscsupsub", "citation-label": "ibscsupsub", "title": "<i>i</i><b>b</b><span style=\"font-variant: small-caps;\">sc</span><sup>sup</sup><sub>sub</sub>"},
-        {"type": "book", "id": "sc", "citation-label": "sc", "title": "<span style=\"font-variant: small-caps;\">sc</span>"},
+        {"type": "book", "id": "sc", "citation-label": "sc", "container-title": "<span style=\"font-variant: small-caps;\">sc</span>"},
         {"type": "book", "id": "sc", "citation-label": "sc", "title": "<span class=\"nocase\">sc</span>"}
       ]
     ],

--- a/packages/plugin-bibtex/test/input.json
+++ b/packages/plugin-bibtex/test/input.json
@@ -83,10 +83,10 @@
       ]
     ],
     "with rich text": [
-      "@misc{ibscsupsub, title={{\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}}, } @misc{sc, title={{\\textsc{sc}}}, } @misc{sc, title={{{sc}}}, }",
+      "@misc{ibscsupsub, title={\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}}, } @misc{sc, title={\\textsc{sc}}, } @misc{sc, title={{{sc}}}, }",
       [
-        {"type": "book", "id": "ibscsupsub", "citation-label": "ibscsupsub", "title": "<i>i</i><b>b</b><sc>sc</sc><sup>sup</sup><sub>sub</sub>"},
-        {"type": "book", "id": "sc", "citation-label": "sc", "title": "<sc>sc</sc>"},
+        {"type": "book", "id": "ibscsupsub", "citation-label": "ibscsupsub", "title": "<i>i</i><b>b</b><span style=\"font-variant: small-caps;\">sc</span><sup>sup</sup><sub>sub</sub>"},
+        {"type": "book", "id": "sc", "citation-label": "sc", "title": "<span style=\"font-variant: small-caps;\">sc</span>"},
         {"type": "book", "id": "sc", "citation-label": "sc", "title": "<span class=\"nocase\">sc</span>"}
       ]
     ],

--- a/packages/plugin-bibtex/test/output.json
+++ b/packages/plugin-bibtex/test/output.json
@@ -32,8 +32,8 @@
     ],
     "rich text title": [
       [
-        {"title": "<i>i</i><b>b</b><sc>sc</sc><sup>sup</sup><sub>sub</sub>"},
-        {"title": "<span style=\"font-variant:small-caps;\">sc</span>"},
+        {"title": "<i>i</i><b>b</b><span style=\"font-variant: small-caps;\">sc</span><sup>sup</sup><sub>sub</sub>"},
+        {"title": "<span style=\"font-variant: small-caps;\">sc</span>"},
         {"title": "<span class=\"nocase\">sc</span>"}
       ],
       "@misc{ibscsupsub,\n\ttitle = {\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}},\n}\n@misc{sc,\n\ttitle = {\\textsc{sc}},\n}\n@misc{sc,\n\ttitle = {{sc}},\n}"

--- a/packages/plugin-bibtex/test/output.json
+++ b/packages/plugin-bibtex/test/output.json
@@ -33,10 +33,10 @@
     "rich text title": [
       [
         {"title": "<i>i</i><b>b</b><span style=\"font-variant: small-caps;\">sc</span><sup>sup</sup><sub>sub</sub>"},
-        {"title": "<span style=\"font-variant: small-caps;\">sc</span>"},
+        {"id": "sc", "container-title": "<span style=\"font-variant: small-caps;\">sc</span>"},
         {"title": "<span class=\"nocase\">sc</span>"}
       ],
-      "@misc{ibscsupsub,\n\ttitle = {\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}},\n}\n@misc{sc,\n\ttitle = {\\textsc{sc}},\n}\n@misc{sc,\n\ttitle = {{sc}},\n}"
+      "@misc{ibscsupsub,\n\ttitle = {\\textit{i}\\textbf{b}\\textsc{sc}\\textsuperscript{sup}\\textsubscript{sub}},\n}\n@misc{sc,\n\tjournal = {\\textsc{sc}},\n}\n@misc{sc,\n\ttitle = {{sc}},\n}"
     ],
     "editor": [
       [


### PR DESCRIPTION
The current CSL-JSON specification requires `<span style="font-variant: small-caps;">` for small caps as opposed to the `<sc>` currently used by this library.

Also, HTML is allowed in all ordinary fields (https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#ordinary-fields).