### PR TITLE
Add Semantic Scholar s2id to biblatex mapping.

### DIFF
--- a/packages/plugin-bibtex/src/mapping/biblatex.js
+++ b/packages/plugin-bibtex/src/mapping/biblatex.js
@@ -47,6 +47,13 @@ const nonSpec = [
     when: {
       target: false
     }
+  },
+  {
+    source: 's2id',
+    target: 'S2ID',
+    when: {
+      target: false
+    }
   }
 ]
 

--- a/packages/plugin-bibtex/src/mapping/biblatex.js
+++ b/packages/plugin-bibtex/src/mapping/biblatex.js
@@ -50,7 +50,7 @@ const nonSpec = [
   },
   {
     source: 's2id',
-    target: 'S2ID',
+    target: '_S2ID',
     when: {
       target: false
     }


### PR DESCRIPTION
Akin to existing support for `PMID` and `PMCID` identifiers, this PR adds support for copying a `s2id` field in bibtex/biblatex to a corresponding `S2ID` key in CSL-JSON. This addition would allow [Semantic Scholar](https://www.semanticscholar.org/) identifiers to be preserved in the mapping process.