### PR TITLE
Reformat json file

### DIFF
--- a/packages/plugin-bibtex/src/input/required.json
+++ b/packages/plugin-bibtex/src/input/required.json
@@ -1,1 +1,310 @@
-{"biblatex":{"article":["author","title","journaltitle",["year","date"]],"book":["author","title",["year","date"]],"mvbook":["author","title",["year","date"]],"inbook":["author","title","booktitle",["year","date"]],"booklet":[["author","editor"],"title",["year","date"]],"collection":["editor","title",["year","date"]],"mvcollection":["editor","title",["year","date"]],"incollection":["author","title","booktitle",["year","date"]],"dataset":[["author","editor"],"title",["year","date"]],"online":[["author","editor"],"title",["year","date"],["doi","eprint","url"]],"patent":["author","title","number",["year","date"]],"periodical":["editor","title",["year","date"]],"proceedings":["title",["year","date"]],"mvproceedings":["title",["year","date"]],"inproceedings":["author","title","booktitle",["year","date"]],"report":["author","title","type","institution",["year","date"]],"thesis":["author","title","type","institution",["year","date"]],"unpublished":["author","title",["year","date"]],"conference":["author","title","booktitle",["year","date"]],"electronic":[["author","editor"],"title",["year","date"],["doi","eprint","url"]],"mastersthesis":["author","title","institution",["year","date"]],"phdthesis":["author","title","institution",["year","date"]],"techreport":["author","title","institution",["year","date"]],"www":[["author","editor"],"title",["year","date"],["doi","eprint","url"]]},"bibtex":{"article":["author","title","journal","year"],"book":[["author","editor"],"title","publisher","year"],"booklet":["title"],"inbook":[["author","editor"],"title",["chapter","pages"],"publisher","year"],"incollection":["author","title","booktitle","publisher","year"],"inproceedings":["author","title","booktitle","year"],"mastersthesis":["author","title","school","year"],"phdthesis":["author","title","school","year"],"proceedings":["title","year"],"techreport":["author","title","institution","year"],"unpublished":["author","title","note"]}}
+{
+  "biblatex": {
+    "article": [
+      "author",
+      "title",
+      "journaltitle",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "book": [
+      "author",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "mvbook": [
+      "author",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "inbook": [
+      "author",
+      "title",
+      "booktitle",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "booklet": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "collection": [
+      "editor",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "mvcollection": [
+      "editor",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "incollection": [
+      "author",
+      "title",
+      "booktitle",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "dataset": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "online": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "year",
+        "date"
+      ],
+      [
+        "doi",
+        "eprint",
+        "url"
+      ]
+    ],
+    "patent": [
+      "author",
+      "title",
+      "number",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "periodical": [
+      "editor",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "proceedings": [
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "mvproceedings": [
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "inproceedings": [
+      "author",
+      "title",
+      "booktitle",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "report": [
+      "author",
+      "title",
+      "type",
+      "institution",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "thesis": [
+      "author",
+      "title",
+      "type",
+      "institution",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "unpublished": [
+      "author",
+      "title",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "conference": [
+      "author",
+      "title",
+      "booktitle",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "electronic": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "year",
+        "date"
+      ],
+      [
+        "doi",
+        "eprint",
+        "url"
+      ]
+    ],
+    "mastersthesis": [
+      "author",
+      "title",
+      "institution",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "phdthesis": [
+      "author",
+      "title",
+      "institution",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "techreport": [
+      "author",
+      "title",
+      "institution",
+      [
+        "year",
+        "date"
+      ]
+    ],
+    "www": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "year",
+        "date"
+      ],
+      [
+        "doi",
+        "eprint",
+        "url"
+      ]
+    ]
+  },
+  "bibtex": {
+    "article": [
+      "author",
+      "title",
+      "journal",
+      "year"
+    ],
+    "book": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      "publisher",
+      "year"
+    ],
+    "booklet": [
+      "title"
+    ],
+    "inbook": [
+      [
+        "author",
+        "editor"
+      ],
+      "title",
+      [
+        "chapter",
+        "pages"
+      ],
+      "publisher",
+      "year"
+    ],
+    "incollection": [
+      "author",
+      "title",
+      "booktitle",
+      "publisher",
+      "year"
+    ],
+    "inproceedings": [
+      "author",
+      "title",
+      "booktitle",
+      "year"
+    ],
+    "mastersthesis": [
+      "author",
+      "title",
+      "school",
+      "year"
+    ],
+    "phdthesis": [
+      "author",
+      "title",
+      "school",
+      "year"
+    ],
+    "proceedings": [
+      "title",
+      "year"
+    ],
+    "techreport": [
+      "author",
+      "title",
+      "institution",
+      "year"
+    ],
+    "unpublished": [
+      "author",
+      "title",
+      "note"
+    ]
+  }
+}


### PR DESCRIPTION
Hi, I am a @JabRef developer. I am doing my [GSoC project](https://jabref.github.io/GSoC/posts/libreoffice/) on implementing compatibility between JabRef and Zotero, which requires a mapping logic between CSL JSON and Bib(La)TeX. That is why I found this project. Thank you very much for your work, it helps a lot!

While checking the codebase, I found required.json is not formatted, so I updated the file a bit.

Would appreciate your feedback!