### PR TITLE
refactor(core): use native fetch instead of node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16792,7 +16792,6 @@
       "dependencies": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
-        "node-fetch": "^3.3.2",
         "sync-fetch": "^0.6.0"
       },
       "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@citation-js/date": "^0.5.0",
     "@citation-js/name": "^0.4.2",
-    "node-fetch": "^3.3.2",
     "sync-fetch": "^0.6.0"
   }
 }

--- a/packages/core/src/util/fetchFile.js
+++ b/packages/core/src/util/fetchFile.js
@@ -1,14 +1,10 @@
 import syncFetch from 'sync-fetch'
-import nodeFetch, { Headers as nodeFetchHeaders } from 'node-fetch'
 
 import logger from '../logger.js'
 import pkg from '../../package.json'
 
 // Browser environments have CORS enabled
 const isBrowser = typeof location !== 'undefined' && typeof navigator !== 'undefined'
-
-const asyncFetch = isBrowser ? fetch : nodeFetch
-const asyncHeaders = isBrowser ? Headers : nodeFetchHeaders
 
 let userAgent = `Citation.js/${pkg.version}`
 
@@ -32,7 +28,7 @@ if (typeof process !== 'undefined' && process && process.release && process.rele
 function normaliseHeaders (headers) {
   const result = {}
 
-  const entries = headers instanceof asyncHeaders || headers instanceof syncFetch.Headers
+  const entries = headers instanceof Headers || headers instanceof syncFetch.Headers
     ? Array.from(headers)
     : Object.entries(headers)
   for (const [name, header] of entries) {
@@ -159,7 +155,7 @@ export async function fetchFileAsync (url, opts) {
 
   logger.http('[core]', reqOpts.method, url, reqOpts)
 
-  return asyncFetch(url, reqOpts)
+  return fetch(url, reqOpts)
     .then(response => checkResponse(response, reqOpts))
     .then(response => response.text())
 }

--- a/packages/core/test/server.js
+++ b/packages/core/test/server.js
@@ -15,9 +15,14 @@ const server = http.createServer(function router (req, res) {
       let body = ''
       req.on('data', c => { body += c })
       req.on('end', function () {
+        // Drop client-injected headers that differ between fetch implementations.
+        const headers = { ...req.headers }
+        for (const name of ['accept-encoding', 'accept-language', 'sec-fetch-mode']) {
+          delete headers[name]
+        }
         res.end(JSON.stringify({
           method: req.method,
-          headers: req.headers,
+          headers,
           body
         }))
       })

--- a/packages/core/test/util.spec.js
+++ b/packages/core/test/util.spec.js
@@ -24,10 +24,9 @@ function deepNotEqual (a, b) {
 function getHeaders (headers) {
   return {
     accept: '*/*',
-    'accept-encoding': 'gzip, deflate, br',
     connection: 'keep-alive',
     host: 'localhost:30200',
-    'user-agent': 'node-fetch',
+    'user-agent': 'node',
     ...headers
   }
 }


### PR DESCRIPTION
`@citation-js/core` requires Node >=20.19, where `fetch` is available natively, so the `node-fetch` dependency is not needed on node.

Specifically, this unbreaks the library from building in Vite/Webpack which typically can not handle `node:` imports in web bundles without polyfills.